### PR TITLE
dont record stats of current day if errors are present

### DIFF
--- a/src/corrections/correction_builder.rs
+++ b/src/corrections/correction_builder.rs
@@ -225,6 +225,10 @@ impl CorrectionBuilder {
     pub fn set_delete(&mut self, delete: bool) {
         self.correction.delete = delete;
     }
+
+    pub fn correction(&self) -> &Correction {
+        &self.correction
+    }
 }
 
 fn save_correction(correction: &Correction) {

--- a/src/proc/rip.rs
+++ b/src/proc/rip.rs
@@ -111,7 +111,12 @@ pub(crate) fn season(
                     }
                     Ok(None) => {} //dont create a box score if it needs to be deleted
                     Err(correction) => {
-                        corrections.push(correction);
+                        //any exceptions
+                        if correction.correction().game_date.is_today() {
+                            //omit games that are wrong if they are potentially still being recorded
+                        } else {
+                            corrections.push(correction);
+                        }
                     }
                 },
                 Team => match fields_to_team_box_score(&fields) {
@@ -120,7 +125,11 @@ pub(crate) fn season(
                     }
                     Ok(None) => {} //dont create a box score if it needs to be deleted
                     Err(correction) => {
-                        corrections.push(correction);
+                        if correction.correction().game_date.is_today() {
+                            //omit games that are wrong if they are potentially still being recorded
+                        } else {
+                            corrections.push(correction);
+                        }
                     }
                 },
                 LineUp => unimplemented!("lineup stats are not yet supported."),

--- a/src/types/game/game_date.rs
+++ b/src/types/game/game_date.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, NaiveDate};
+use chrono::{Datelike, Local, NaiveDate};
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -57,6 +57,10 @@ impl GameDate {
 
     pub fn timestamp(&self) -> i32 {
         self.0.to_epoch_days()
+    }
+
+    pub fn is_today(&self) -> bool {
+        self.0 == Local::now().date_naive()
     }
 }
 


### PR DESCRIPTION
this adds a feature to not attempt to correct stats recorded on the same day. typically the issues in the data are corrected and inputted night of. 
- tested on irl case 12/1/2025