### PR TITLE
fixed command `warheads sync`

### DIFF
--- a/src/dapi/store_disk.rs
+++ b/src/dapi/store_disk.rs
@@ -2,14 +2,14 @@ use crate::format::path_manager::nba_storage_path;
 
 use crate::stats::game_obj::GameObject;
 
+use crate::types::SeasonId;
+
 use std::fmt::Display;
 use std::fs;
 use thiserror::Error;
 
-use SaveGameError::{CreateDirectoryError, FileWriteError, WincodeSerializationError};
-
-pub fn save_nba_games(games: &[GameObject]) -> Result<(), SaveGameError> {
-    let season_id = games[0].season();
+pub fn save_nba_games(season_id: SeasonId, games: &[GameObject]) -> Result<(), SaveGameError> {
+    use SaveGameError::{CreateDirectoryError, FileWriteError, WincodeSerializationError};
 
     let contents = wincode::serialize(&games).map_err(|e| WincodeSerializationError(e))?;
 

--- a/src/proc/dispatch.rs
+++ b/src/proc/dispatch.rs
@@ -84,16 +84,7 @@ impl Dispatch {
             // data procedures
             Commands::Init => initialize().await,
 
-            Commands::Sync => match update_source_data().await {
-                Ok(_) => {
-                    println!("✅ successfully updated source data.");
-                    Ok(())
-                }
-                Err(_) => {
-                    println!("❌ failed to update source data.");
-                    Err(DispatchError::SourceDataError)
-                }
-            },
+            Commands::Sync => update_local_files().await,
 
             Commands::Checksums { action } => match action {
                 ChecksumCommand::Verify => {
@@ -236,5 +227,17 @@ async fn initialize() -> Result<(), DispatchError> {
     annotate_nba().await;
     chronicle_nba();
     println!("✅ successfully initialized NBA data in warheads directory.");
+    Ok(())
+}
+
+async fn update_local_files() -> Result<(), DispatchError> {
+    let _ = update_source_data()
+        .await
+        .map_err(|_| DispatchError::SourceDataError)?;
+    println!("✅ successfully updated source data.");
+
+    let _ = chronicle_nba();
+    println!("✅ NBA volumes created successfully.");
+
     Ok(())
 }

--- a/src/proc/gather.rs
+++ b/src/proc/gather.rs
@@ -1,24 +1,45 @@
 use std::fs::File;
 use std::io::Read;
 
+use serde_json::Value;
+
 use crate::dapi::player_box_score::PlayerBoxScore;
 use crate::dapi::team_box_score::TeamBoxScore;
 
 use crate::edit::edit_list::EditList;
+
+use crate::edit::edit_loader::{load_edit_list, save_edit_list};
 use crate::format::parse::parse_season;
 use crate::format::path_manager::nba_source_path;
 
 use crate::proc::error::ReadProcessError;
-use crate::proc::query;
-use crate::proc::rip::generate_nba_games_from_data;
+use crate::proc::rip;
+use crate::proc::rip::ProcessingResult;
 
 use crate::stats::identity::Identity;
 use crate::stats::nba_kind::NBAStatKind;
-use crate::stats::nba_stat::NBABoxScore::{Player, Team};
-
-use crate::dapi::write::write_serializable_with_directory;
+use crate::stats::nba_stat::NBABoxScore::{self, Player, Team};
 
 use crate::types::SeasonId;
+
+pub fn load_season_from_source(
+    era: SeasonId,
+) -> Result<Vec<(Identity, TeamBoxScore)>, ReadProcessError> {
+    let mut edit_list: EditList = load_edit_list().unwrap_or_default();
+
+    let mut team_games_vec = Vec::new();
+
+    let player_games_of_period = load_player_games_from_source(era, &mut edit_list)?;
+
+    let team_games_of_period =
+        load_team_games_from_source(era, player_games_of_period, &mut edit_list)?;
+
+    save_edit_list(&edit_list).map_err(|_| ReadProcessError::SerializeEditError)?;
+
+    team_games_vec.extend(team_games_of_period);
+
+    Ok(team_games_vec)
+}
 
 pub fn load_player_games_from_source(
     season_id: SeasonId,
@@ -38,7 +59,7 @@ pub fn load_player_games_from_source(
     let (rows, headers) =
         parse_season(json).map_err(|e| ReadProcessError::ObjectStructureError(e))?;
 
-    Ok(generate_nba_games_from_data(headers, rows, edit_list)?
+    Ok(generate_nba_games_from_source(headers, rows, edit_list)?
         .into_iter()
         .filter_map(|(id, stat)| match stat {
             Player(box_score) => Some((id, box_score)),
@@ -67,7 +88,7 @@ pub fn load_team_games_from_source(
         parse_season(json).map_err(|e| ReadProcessError::ObjectStructureError(e))?;
 
     let mut games: Vec<(Identity, TeamBoxScore)> =
-        generate_nba_games_from_data(headers, rows, edit_list)?
+        generate_nba_games_from_source(headers, rows, edit_list)?
             .into_iter()
             .filter_map(|(id, stat)| match stat {
                 Team(t) => Some((id, t)),
@@ -86,28 +107,54 @@ pub fn load_team_games_from_source(
     Ok(games)
 }
 
-pub async fn fetch_and_save_nba_stats(season: SeasonId, stat: NBAStatKind) -> Result<(), String> {
-    let file_path = nba_source_path(season, stat);
+fn generate_nba_games_from_source(
+    headers: Vec<String>,
+    rows: Vec<Value>,
+    edits: &mut EditList,
+) -> Result<Vec<(Identity, NBABoxScore)>, ReadProcessError> {
+    let mut games = Vec::new();
 
-    let (year, _period) = season.destructure();
+    let mut results = rip::season(rows.clone(), headers.clone(), edits)?;
 
-    match query::nba_history_json(season, stat).await {
-        Ok(response_data) => match write_serializable_with_directory(&file_path, &response_data) {
-            Ok(_) => {
-                println!(
-                    "✅ successfully saved nba stats for {} season at file: {:?}",
-                    season, &file_path
-                );
-                Ok(())
-            }
-            Err(e) => Err(format!(
-                "❌ error saving nba stats for {} season at file {:?}: {}",
-                season, &file_path, e
-            )),
-        },
-        Err(e) => Err(format!(
-            "❌ failed to fetch {} stats for {} season: {:?}",
-            year, stat, e
-        )),
+    let mut incompletions = 0;
+
+    for result in results.iter_mut() {
+        match result {
+            ProcessingResult::Record(identity, boxscore) => {
+                games.push((identity.to_owned(), boxscore.to_owned()))
+            },
+            ProcessingResult::Edit(edit_builder) => {
+                if edit_builder.date().is_today() {
+                    println!("⏳ game is live. omitting stats.")
+                } else {
+                    edit_builder.prompt(); //starts the tui prompter
+
+                    let edit = edit_builder.build().ok_or(ReadProcessError::BuildEditError)?;
+
+                    edits.insert(edit);
+
+                    incompletions += 1;
+                }
+            },
+            ProcessingResult::Delete(ident) => match ident.team_or_player() {
+                NBAStatKind::Team => println!(
+                    "🗑️ deleting team record for {} game: {}. all associated player records will be ignored",
+                    ident.team_abbr(),
+                    ident.game_id
+                ),
+                NBAStatKind::Player => println!(
+                    "🗑️ deleting player record for id: {} game: {}. the respective game object will not be affected though stat totals may not be consistent.",
+                    ident.player_id.unwrap(),
+                    ident.game_id
+                ),
+                NBAStatKind::LineUp => unimplemented!(),
+            },
+        }
+    }
+
+    if incompletions > 0 {
+        generate_nba_games_from_source(headers, rows, edits)
+    } else {
+        Ok(games)
     }
 }

--- a/src/proc/historian.rs
+++ b/src/proc/historian.rs
@@ -10,8 +10,8 @@ use crate::format::path_manager::nba_checksum_file;
 use crate::ml::model::Model;
 use crate::ml::models::elo_models::elo_tracker::EloTracker;
 
-use crate::proc::gather::fetch_and_save_nba_stats;
 use crate::proc::hunting::compare_and_fetch;
+use crate::proc::hunting::fetch_and_save_nba_stats;
 use crate::proc::query::nba_annotation_file;
 use crate::proc::store::inscribe;
 

--- a/src/proc/hunting.rs
+++ b/src/proc/hunting.rs
@@ -1,18 +1,12 @@
 use crate::checksum::checksum_map::ChecksumMap;
 use crate::checksum::read_checksum::read_checksum;
 
-use crate::dapi::team_box_score::TeamBoxScore;
-
-use crate::edit::edit_list::EditList;
-use crate::edit::edit_loader::{load_edit_list, save_edit_list};
+use crate::dapi::write::write_serializable_with_directory;
 
 use crate::format::path_manager::{nba_source_path, universal_nba_source_path};
 
-use crate::proc::error::ReadProcessError;
-use crate::proc::gather;
-use crate::proc::gather::{load_player_games_from_source, load_team_games_from_source};
+use crate::proc::query;
 
-use crate::stats::identity::Identity;
 use crate::stats::nba_kind::NBAStatKind;
 
 use crate::types::SeasonId;
@@ -22,24 +16,30 @@ use crate::types::SeasonId;
     this shit is NOT easy for me f*ck
 */
 
-//change to result
-pub fn load_season_from_source(
-    era: SeasonId,
-) -> Result<Vec<(Identity, TeamBoxScore)>, ReadProcessError> {
-    let mut edit_list: EditList = load_edit_list().unwrap_or_default();
+pub async fn fetch_and_save_nba_stats(season: SeasonId, stat: NBAStatKind) -> Result<(), String> {
+    let file_path = nba_source_path(season, stat);
 
-    let mut team_games_vec = Vec::new();
+    let (year, _period) = season.destructure();
 
-    let player_games_of_period = load_player_games_from_source(era, &mut edit_list)?;
-
-    let team_games_of_period =
-        load_team_games_from_source(era, player_games_of_period, &mut edit_list)?;
-
-    save_edit_list(&edit_list).map_err(|_| ReadProcessError::SerializeEditError)?;
-
-    team_games_vec.extend(team_games_of_period);
-
-    Ok(team_games_vec)
+    match query::nba_history_json(season, stat).await {
+        Ok(response_data) => match write_serializable_with_directory(&file_path, &response_data) {
+            Ok(_) => {
+                println!(
+                    "✅ successfully saved nba stats for {} season at file: {:?}",
+                    season, &file_path
+                );
+                Ok(())
+            }
+            Err(e) => Err(format!(
+                "❌ error saving nba stats for {} season at file {:?}: {}",
+                season, &file_path, e
+            )),
+        },
+        Err(e) => Err(format!(
+            "❌ failed to fetch {} stats for {} season: {:?}",
+            year, stat, e
+        )),
+    }
 }
 
 /// Compare the checksums of a NBA data source file and if it matches the expected checksum we can bypass refetching from
@@ -55,7 +55,7 @@ pub(crate) async fn compare_and_fetch(
     //why would you expect this if ur looking whether something is initialized correctly??? dummy
     //
     if let Err(_) = read_checksum(&source_path) {
-        if let Err(msg) = gather::fetch_and_save_nba_stats(season_id, kind).await {
+        if let Err(msg) = fetch_and_save_nba_stats(season_id, kind).await {
             println!("{}", msg);
         } else {
             println!("✅ successfully wrote {kind} data to file for the {season_id}");
@@ -66,7 +66,7 @@ pub(crate) async fn compare_and_fetch(
         if expected_checksum.is_none() || checksum != *expected_checksum.unwrap()
         //this might fail on new records
         {
-            if let Err(msg) = gather::fetch_and_save_nba_stats(season_id, kind).await {
+            if let Err(msg) = fetch_and_save_nba_stats(season_id, kind).await {
                 println!("{}", msg);
             } else {
                 println!("✅ successfully wrote {kind} data to file for the {season_id}");

--- a/src/proc/refresher.rs
+++ b/src/proc/refresher.rs
@@ -4,7 +4,7 @@ use crate::dapi::season_manager::get_current_era;
 
 use crate::format::parse::parse_gamecards;
 
-use crate::proc::gather::fetch_and_save_nba_stats;
+use crate::proc::hunting::fetch_and_save_nba_stats;
 use crate::proc::query::{get_gamecard_json, NBAQueryError};
 
 use crate::stats::gamecard::GameCard;

--- a/src/proc/revise.rs
+++ b/src/proc/revise.rs
@@ -45,5 +45,7 @@ pub fn revise_nba_season(
         }
     }
 
+    games.retain(|g| !to_delete.contains(&g.0));
+
     Ok(())
 }

--- a/src/proc/rip.rs
+++ b/src/proc/rip.rs
@@ -25,67 +25,13 @@ use serde_json::Value::Null;
 
 use std::collections::HashMap;
 
-enum ProcessingResult {
+pub(super) enum ProcessingResult {
     Record(Identity, NBABoxScore),
     Edit(EditBuilder),
     Delete(Identity),
 }
 
-// TODO: implement the return as a result marking complete failure vs just needing to
-// return corrections.
-pub fn generate_nba_games_from_data(
-    headers: Vec<String>,
-    rows: Vec<Value>,
-    edits: &mut EditList,
-) -> Result<Vec<(Identity, NBABoxScore)>, ReadProcessError> {
-    let mut games = Vec::new();
-
-    let mut results = season(rows.clone(), headers.clone(), edits)?;
-
-    let mut incompletions = 0;
-
-    for result in results.iter_mut() {
-        match result {
-            ProcessingResult::Record(identity, boxscore) => {
-                games.push((identity.to_owned(), boxscore.to_owned()))
-            },
-            ProcessingResult::Edit(edit_builder) => {
-                if edit_builder.date().is_today() {
-                    println!("⏳ game is live. omitting stats.")
-                } else {
-                    edit_builder.prompt(); //starts the tui prompter
-
-                    let edit = edit_builder.build().ok_or(ReadProcessError::BuildEditError)?;
-
-                    edits.insert(edit);
-
-                    incompletions += 1;
-                }
-            },
-            ProcessingResult::Delete(ident) => match ident.team_or_player() {
-                Team => println!(
-                    "🗑️ deleting team record for {} game: {}. all associated player records will be ignored",
-                    ident.team_abbr(),
-                    ident.game_id
-                ),
-                Player => println!(
-                    "🗑️ deleting player record for id: {} game: {}. the respective game object will not be affected though stat totals may not be consistent.",
-                    ident.player_id.unwrap(),
-                    ident.game_id
-                ),
-                LineUp => unimplemented!(),
-            },
-        }
-    }
-
-    if incompletions > 0 {
-        generate_nba_games_from_data(headers, rows, edits)
-    } else {
-        Ok(games)
-    }
-}
-
-fn season(
+pub(super) fn season(
     rows: Vec<Value>,
     headers: Vec<String>,
     edits: &EditList,

--- a/src/proc/store.rs
+++ b/src/proc/store.rs
@@ -4,7 +4,7 @@ use crate::edit::edit_builder::EditBuilder;
 use crate::edit::edit_loader::{load_edit_list, save_edit_list, EditLoadingError};
 
 use crate::proc::error::ReadProcessError;
-use crate::proc::hunting::load_season_from_source;
+use crate::proc::gather::load_season_from_source;
 use crate::proc::revise::revise_nba_season;
 
 use crate::stats::game_obj::GameObject;
@@ -57,9 +57,9 @@ pub fn inscribe(era: SeasonId) -> Result<(), InscriptionError> {
                 let game_id = edit_builder.game_id();
 
                 // look in already-loaded edits for the sibling with same game_id, different team
-                if let Some(resolved) = edits.find_sibling(game_id, edit_builder.team_abbr()) {
-                    if resolved.corrects(&StatColumn::MATCHUP) {
-                        let matchup = resolved.inverse_matchup_as_value().unwrap();
+                if let Some(sibling) = edits.find_sibling(game_id, edit_builder.team_abbr()) {
+                    if sibling.corrects(&StatColumn::MATCHUP) {
+                        let matchup = sibling.inverse_matchup_as_value().unwrap();
 
                         edit_builder.add_missing_field(StatColumn::MATCHUP, matchup);
 
@@ -83,20 +83,10 @@ pub fn inscribe(era: SeasonId) -> Result<(), InscriptionError> {
 
             inscribe(era)
         }
-        Ok(games) => save_game_object(games).map_err(|e| InscriptionError::SerializeGameError(e)),
+        Ok(games) => {
+            save_nba_games(era, &games).map_err(|e| InscriptionError::SerializeGameError(e))
+        }
     }
-}
-
-fn save_game_object(season: Vec<GameObject>) -> Result<(), SaveGameError> {
-    let num_games = season.len();
-
-    if num_games == 0 {
-        return Ok(());
-    }
-
-    save_nba_games(&season)?;
-
-    Ok(())
 }
 
 pub(crate) type TeamGame = (Identity, TeamBoxScore);


### PR DESCRIPTION
- fetches live nba data
- NEW saves new data to nba volumes without extra invocation of `warheads init`
- NEW saves volume for new season period even with 0 recorded games


QOL
- renamed functions to better reflect acting on source or volume data
- reorganized procedures to avoid more calls outside of module 