### PR TITLE
refactored constants::paths to remove need for .env and dotenv crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }         # Async runtime
 serde_json = "1.0.133"
 serde = { version = "1.0.217", features = ["derive"] }
-dotenv = "0.15.0"
 once_cell = "1.20.2"
 derivative = "2.2.0"
 chrono = { version = "0.4.41", features = ["serde"] }

--- a/src/constants/paths.rs
+++ b/src/constants/paths.rs
@@ -1,11 +1,25 @@
-//! TODO: Replace with proper environment handling later
-use dotenv;
-
 pub fn data() -> String {
-    dotenv::dotenv().ok();
+    let curr_dir = std::env::current_exe().expect("💀 could not get current executable path");
 
-    match dotenv::var("DATA") {
-        Ok(s) => s,
-        Err(_) => panic!("💀 could not read DATA from environment. (.env)"),
+    let mut parent = curr_dir.parent();
+    while parent.is_some() && !parent.as_ref().unwrap().file_name().unwrap().eq("warheads") {
+        parent = parent.unwrap().parent();
     }
+
+    if parent.is_none() {
+        panic!("💀 could not find warheads directory");
+    }
+
+    let data_path = parent.unwrap().join("data");
+
+    data_path.to_string_lossy().into_owned()
+}
+
+#[test]
+fn test_data_path() {
+    let path = data();
+    let parts = path.split("/").collect::<Vec<_>>();
+
+    assert_eq!(parts[parts.len() - 1], "data");
+    assert_eq!(parts[parts.len() - 2], "warheads");
 }


### PR DESCRIPTION
- removed dotenv dependency from Cargo.toml
- refactored `constants::paths` to not read env file
- replaced with dynamic evaluation. finds current executable, searches lineage until finds directory `warheads` and appends the data director
- added test to assert directory is correct: assert [..., 'warheads', 'data']]